### PR TITLE
Fix order of pump events delivered to NightscoutUploadKit (#147)

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -842,7 +842,8 @@ final class DeviceDataManager: CarbStoreDelegate, DoseStoreDelegate, Transmitter
         var objectIDs = [NSManagedObjectID]()
         var timestampedPumpEvents = [TimestampedHistoryEvent]()
 
-        for event in pumpEvents {
+        // TODO: LoopKit should return these in chronological order instead of reversing here.
+        for event in pumpEvents.reverse() {
             objectIDs.append(event.objectID)
 
             if let raw = event.raw where raw.length > 0, let type = MinimedKit.PumpEventType(rawValue: raw[0])?.eventType, pumpEvent = type.init(availableData: raw, pumpModel: pumpModel) {


### PR DESCRIPTION
TempBasal and TempBasalDuration must appear in the same order as in the pump
